### PR TITLE
[WIP] Add `onEndEditing` Callback/Prop

### DIFF
--- a/ios/TPSStripe/TPSCardField.h
+++ b/ios/TPSStripe/TPSCardField.h
@@ -12,6 +12,7 @@
 @interface TPSCardField : UIView
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onEndEditing;
 @property (nonatomic, strong) UIFont *font;
 @property(nonatomic, strong) UIColor *textColor;
 @property(nonatomic, strong) UIColor *textErrorColor;

--- a/ios/TPSStripe/TPSCardField.m
+++ b/ios/TPSStripe/TPSCardField.m
@@ -179,4 +179,18 @@
                 });
 }
 
+- (void)paymentCardTextFieldDidEndEditing:(STPPaymentCardTextField *)textField {
+    if (!_onEndEditing) {
+        return;
+    }
+    _onEndEditing(@{
+                @"valid": @(_paymentCardTextField.isValid),
+                @"params": @{
+                        @"number": _paymentCardTextField.cardParams.number?:@"",
+                        @"expMonth": @(_paymentCardTextField.cardParams.expMonth),
+                        @"expYear": @(_paymentCardTextField.cardParams.expYear),
+                        @"cvc": _paymentCardTextField.cardParams.cvc?:@""
+                        }
+                });
+}
 @end

--- a/ios/TPSStripe/TPSCardFieldManager.m
+++ b/ios/TPSStripe/TPSCardFieldManager.m
@@ -51,6 +51,7 @@ RCT_EXPORT_VIEW_PROPERTY(cvcPlaceholder, NSString);
 RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL);
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onEndEditing, RCTBubblingEventBlock);
 
 RCT_CUSTOM_VIEW_PROPERTY(params, NSDictionary, TPSCardField)
 {

--- a/src/components/PaymentCardTextField.android.js
+++ b/src/components/PaymentCardTextField.android.js
@@ -34,10 +34,12 @@ export default class PaymentCardTextField extends Component {
 
     onChange: PropTypes.func,
     onValueChange: PropTypes.func,
+    onEndEditing: PropTypes.func,
   }
 
   static defaultProps = {
     ...View.defaultProps,
+    onEndEditing: () => {},
   }
 
   valid = false // eslint-disable-line react/sort-comp
@@ -68,6 +70,18 @@ export default class PaymentCardTextField extends Component {
 
   handlePress = () => {
     this.focus()
+  }
+
+  handleEndEditing = (event) => {
+    const { onEndEditing } = this.props
+    const { nativeEvent } = event
+
+    if (onEndEditing) {
+      onEndEditing(
+        nativeEvent.valid,
+        nativeEvent.params
+      )
+    }
   }
 
   handleChange = (event) => {
@@ -123,6 +137,7 @@ export default class PaymentCardTextField extends Component {
           enabled={!disabled}
           {...rest}
           onChange={this.handleChange}
+          onEndEditing={this.handleEndEditing}
         />
       </TouchableWithoutFeedback>
     )
@@ -152,5 +167,6 @@ const NativePaymentCardTextField = requireNativeComponent('CreditCardForm', Paym
     fontSize: true,
     enabled: true,
     onChange: true,
+    onEndEditing: true,
   },
 })

--- a/src/components/PaymentCardTextField.android.js
+++ b/src/components/PaymentCardTextField.android.js
@@ -33,12 +33,14 @@ export default class PaymentCardTextField extends Component {
     numberPlaceholder: PropTypes.string,
 
     onChange: PropTypes.func,
+    onParamsChange: PropTypes.func,
     onValueChange: PropTypes.func,
     onEndEditing: PropTypes.func,
   }
 
   static defaultProps = {
     ...View.defaultProps,
+    onParamsChange: () => {},
     onEndEditing: () => {},
   }
 

--- a/src/components/PaymentCardTextField.ios.js
+++ b/src/components/PaymentCardTextField.ios.js
@@ -38,6 +38,7 @@ function getNativeComponent(name) {
       params: true,
       keyboardAppearance: true,
       onChange: true,
+      onEndEditing: true,
     },
   })
 
@@ -69,10 +70,12 @@ export default class PaymentCardTextField extends Component {
 
     onChange: PropTypes.func,
     onValueChange: PropTypes.func,
+    onEndEditing: PropTypes.func,
   }
 
   static defaultProps = {
     ...View.defaultProps,
+    onEndEditing: () => {},
   }
 
   valid = false // eslint-disable-line react/sort-comp
@@ -107,6 +110,18 @@ export default class PaymentCardTextField extends Component {
 
   handlePress = () => {
     this.focus()
+  }
+
+  handleEndEditing = (event) => {
+    const { onEndEditing } = this.props
+    const { nativeEvent } = event
+
+    if (onEndEditing) {
+      onEndEditing(
+        nativeEvent.valid,
+        nativeEvent.params
+      )
+    }
   }
 
   handleChange = (event) => {
@@ -177,6 +192,7 @@ export default class PaymentCardTextField extends Component {
           cvcPlaceholder={cvcPlaceholder}
           keyboardAppearance={keyboardAppearance}
           onChange={this.handleChange}
+          onEndEditing={this.handleEndEditing}
         />
       </TouchableWithoutFeedback>
     )

--- a/src/components/PaymentCardTextField.ios.js
+++ b/src/components/PaymentCardTextField.ios.js
@@ -69,12 +69,14 @@ export default class PaymentCardTextField extends Component {
     keyboardAppearance: PropTypes.oneOf(['default', 'light', 'dark']),
 
     onChange: PropTypes.func,
+    onParamsChange: PropTypes.func,
     onValueChange: PropTypes.func,
     onEndEditing: PropTypes.func,
   }
 
   static defaultProps = {
     ...View.defaultProps,
+    onParamsChange: () => {},
     onEndEditing: () => {},
   }
 

--- a/website/docs-md/paymentcardtextfield.md
+++ b/website/docs-md/paymentcardtextfield.md
@@ -24,6 +24,7 @@ It’s designed to fit on a single line.
 | enabled&nbsp;(Android) | Bool | Enable/disable selecting or editing the field. Useful when submitting card details to Stripe |
 | onChange | Func | This function will be called each input change |
 | onParamsChange(valid&nbsp;Bool,&nbsp;params:&nbsp;Object) | Func | This function will be called each input change, it takes two arguments |
+| onEndEditing(valid&nbsp;Bool,&nbsp;params:&nbsp;Object) | Func | This function will be called after the user's focus moves outside of the combined inputs |
 
 **onParamsChange params**
 


### PR DESCRIPTION
Addresses https://github.com/tipsi/tipsi-stripe/issues/277

### :stop_sign: **INCOMPLETE** :no_good_man: 

This PR adds support for passing an `onEndEditing` prop to the `PaymentCardTextField` in order to receive a callback when the user "blurs" the field (in quotations because the field is comprised of 3 inner text fields each of which will receive `focus` and `blur` events as the user moves through the form). This is useful for triggered additional behavior after a user has moved away from editing the field.

**TODO**:
- **ANDROID**: Figure out how to add this behavior to the Android native module
- Figure out how to run the tests (requires test `PUBLISHABLE_KEY` and `MERCHANT_ID` ??)

**Questions**:
- Is `onValueChange` used anywhere? It does not appear to be however it is one of the props that's passed to the Native module via rest props (`...rest`).
- For the `onEndEditing` callback, what value makes the most sense to pass through? I just duplicated what `onChange` does (passing `valid` and `params`).
- Should we just add support for [all of the callbacks](https://github.com/stripe/stripe-ios/blob/v13.0.0/Stripe/PublicHeaders/STPPaymentCardTextField.h#L323-L379) that the underlying module exposes? The full list is below:

    - `onBeginEditing`
    - `onEndEditing`
    - `onBeginEditingNumber`
    - `onEndEditingNumber`
    - `onBeginEditingExpiration`
    - `onEndEditingExpiration`
    - `onBeginEditingCVC`
    - `onEndEditingCVC`
    - `onBeginEditingPostalCode` (?)
    - `onEndEditingPostalCode` (?)

```objc
/**
 Called when editing begins in the text field as a whole. 
 
 After receiving this callback, you will always also receive a callback for which
 specific subfield of the view began editing.
 */
- (void)paymentCardTextFieldDidBeginEditing:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing ends in the text field as a whole.
 This callback is always preceded by an callback for which
 specific subfield of the view ended its editing.
 */
- (void)paymentCardTextFieldDidEndEditing:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing begins in the payment card field's number field.
 */
- (void)paymentCardTextFieldDidBeginEditingNumber:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing ends in the payment card field's number field.
 */
- (void)paymentCardTextFieldDidEndEditingNumber:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing begins in the payment card field's CVC field.
 */
- (void)paymentCardTextFieldDidBeginEditingCVC:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing ends in the payment card field's CVC field.
 */
- (void)paymentCardTextFieldDidEndEditingCVC:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing begins in the payment card field's expiration field.
 */
- (void)paymentCardTextFieldDidBeginEditingExpiration:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing ends in the payment card field's expiration field.
 */
- (void)paymentCardTextFieldDidEndEditingExpiration:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing begins in the payment card field's ZIP/postal code field.
 */
- (void)paymentCardTextFieldDidBeginEditingPostalCode:(nonnull STPPaymentCardTextField *)textField;

/**
 Called when editing ends in the payment card field's ZIP/postal code field.
 */
- (void)paymentCardTextFieldDidEndEditingPostalCode:(nonnull STPPaymentCardTextField *)textField;
```